### PR TITLE
Implement compressed instructions (rv32ic)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ By having multiple banks of registers mapped in memory (page-zero, page-one, pag
 
 Zero-page etc not implemented.
 
-Currently only rv32i.  Compressed instuctions will follow. 
+Now compressed instructions (rv32ic) are done.
 
 Adapted from Clifford Wolf's picrorc32 :  https://github.com/cliffordwolf/picorv32
 

--- a/minrv32-formal/checks.cfg
+++ b/minrv32-formal/checks.cfg
@@ -1,6 +1,6 @@
 
 [options]
-isa rv32i
+isa rv32ic
 
 [depth]
 insn            10


### PR DESCRIPTION
Hi, we are the team from NCKU.
Our computer architecture project is to implement compressed instructions on minrv32.
We have implemented all the instructions in `riscv-formal/insns/isa_rv32ic.txt` and we have checked the correctness of the instructions by `RISCV Formal Checking`.

To make RV32I compatible with RV32IC, we find that misaligned exceptions are not possible on machines support 16-bit aligned instruction. Therefore, we remove the misaligned checks for B and J type instructions.

However, `reg_ch0` and `causal_ch0` still error.

Thank you.